### PR TITLE
Add additional flags for remove

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -184,7 +184,7 @@ function delete_vm ()
             || yellow "(Domain is not running.)"
 
         outputn "Undefining ${VMNAME} domain"
-        virsh undefine ${VMNAME} > /dev/null 2>&1 \
+        virsh undefine --managed-save ${VMNAME} > /dev/null 2>&1 \
             && ok \
             || die "Could not undefine domain."
     else

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -179,7 +179,7 @@ function delete_vm ()
     if [ "${DOMAIN_EXISTS}" -eq 1 ]
     then
         outputn "Destroying ${VMNAME} domain"
-        virsh destroy ${VMNAME} > /dev/null 2>&1 \
+        virsh destroy --graceful ${VMNAME} > /dev/null 2>&1 \
             && ok \
             || yellow "(Domain is not running.)"
 


### PR DESCRIPTION
Thanks for this awesome script!

This PR adds flags to remove command. The graceful command is just being nice. The other flag fixes the issue with remove after reboot.

```
- Undefining XXX domain ... ERR: Could not undefine domain.
```

BTW conciser not redirecting `stderr` to `/dev/null`