### PR TITLE
Add Fedora 28 as a supported release

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ DISTRIBUTIONS
     fedora26-atomic Fedora 26 Atomic Host               fedora
     fedora27        Fedora 27                           fedora
     fedora27-atomic Fedora 27 Atomic Host               fedora
+    fedora28        Fedora 28                           fedora
+    fedora28-atomic Fedora 28 Atomic Host               fedora
     ubuntu1604      Ubuntu 16.04 LTS (Xenial Xerus)     ubuntu
 
 EXAMPLES

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -76,6 +76,8 @@ function usage_subcommand ()
             printf "    fedora26-atomic Fedora 26 Atomic Host               fedora\n"
             printf "    fedora27        Fedora 27                           fedora\n"
             printf "    fedora27-atomic Fedora 27 Atomic Host               fedora\n"
+            printf "    fedora28        Fedora 28                           fedora\n"
+            printf "    fedora28-atomic Fedora 28 Atomic Host               fedora\n"
             printf "    ubuntu1604      Ubuntu 16.04 LTS (Xenial Xerus)     ubuntu\n"
             printf "\n"
             printf "EXAMPLES\n"
@@ -269,16 +271,28 @@ function fetch_images ()
             ;;
         fedora27)
             QCOW=Fedora-Cloud-Base-27-1.6.x86_64.qcow2
-            OS_VARIANT="fedora26"
+            OS_VARIANT="fedora27"
             IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images
             LOGIN_USER=fedora
             ;;
         fedora27-atomic)
             QCOW=Fedora-Atomic-27-1.6.x86_64.qcow2
-            OS_VARIANT="fedora26"
+            OS_VARIANT="fedora27"
             IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images
             LOGIN_USER=fedora
             ;;
+        fedora28)
+          QCOW=Fedora-Cloud-Base-28-1.1.x86_64.qcow2
+          OS_VARIANT="fedora27"
+          IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images
+          LOGIN_USER=fedora
+          ;;
+        fedora28-atomic)
+          QCOW=Fedora-AtomicHost-28-20180425.0.x86_64.qcow2
+          OS_VARIANT="fedora27"
+          IMAGE_URL=https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-28-20180425.0/AtomicHost/x86_64/images
+          LOGIN_USER=fedora
+          ;;
         ubuntu1604)
             QCOW=ubuntu-16.04-server-cloudimg-amd64-disk1.img
             OS_VARIANT="ubuntu16.04"

--- a/tests/check_distributions.bats
+++ b/tests/check_distributions.bats
@@ -52,6 +52,10 @@ function remove_test_vm ()
     create_test_vm fedora27
 }
 
+@test "Delete VM (Fedora 27) - $VMNAME-fedora27" {
+    remove_test_vm fedora27
+}
+
 @test "Install VM (Fedora 27 Atomic) - $VMNAME-fedora27-atomic" {
     create_test_vm fedora27-atomic
 }
@@ -60,8 +64,20 @@ function remove_test_vm ()
     remove_test_vm fedora27-atomic
 }
 
-@test "Delete VM (Fedora 27) - $VMNAME-fedora27" {
-    remove_test_vm fedora27
+@test "Install VM (Fedora 28) - $VMNAME-fedora28" {
+    create_test_vm fedora28
+}
+
+@test "Delete VM (Fedora 28) - $VMNAME-fedora28" {
+    remove_test_vm fedora28
+}
+
+@test "Install VM (Fedora 28 Atomic) - $VMNAME-fedora28-atomic" {
+    create_test_vm fedora28-atomic
+}
+
+@test "Delete VM (Fedora 28 Atomic) - $VMNAME-fedora28-atomic" {
+    remove_test_vm fedora28-atomic
 }
 
 @test "Install VM (Ubuntu 16.04) - $VMNAME-ubuntu1604" {


### PR DESCRIPTION
Pretty straightforward, I basically just copied the code for the other Fedora releases. The only gotcha I ran into is the cloud images are now stored in a directory on mirrors called "Cloud", rather than "CloudImages" for Fedora 27.