### PR TITLE
If id_rsa.pub doesn't exist, check for id_dsa.pub or id_ed25519.pub

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -318,6 +318,17 @@ function fetch_images ()
 
 function check_ssh_key ()
 {
+    local key
+    if [ -z "${PUBKEY}" ]; then
+        # Try to find a suitable key file.
+        for key in ~/.ssh/id_{rsa,dsa,ed25519}.pub; do
+            if [ -f "$key" ]; then
+                PUBKEY="$key"
+                break
+            fi
+        done
+    fi
+
     if [ ! -f "${PUBKEY}" ]
     then
         # Check for existence of a pubkey, or else exit with message
@@ -663,7 +674,7 @@ function set_defaults ()
     RESIZE_DISK=false               # Resize disk (boolean)
     IMAGEDIR=${HOME}/virt/images    # Directory to store images
     BRIDGE=virbr0                   # Hypervisor bridge
-    PUBKEY=${HOME}/.ssh/id_rsa.pub  # SSH public key
+    PUBKEY=""                       # SSH public key
     DISTRO=centos7                  # Distribution
     MACADDRESS=""                   # MAC Address
     PORT=-1                         # Console port


### PR DESCRIPTION
I personally don't use an RSA SSH key, instead I use an ED25519 key. This means that I always need to use commands like `-k ~/.ssh/id_ed25519.pub` when creating VMs.

The change here makes `kvm-install-vm` look for a DSA or ED25519 key if an RSA key can't be found. This will improve situations like mine where the user is using a standard key file name for an alternate key algorithm. It just chooses the first key found in a list (starting with RSA) rather than checking for multiple keys.