### PR TITLE
Don't use virt-resize on ubuntu1804

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -484,11 +484,18 @@ _EOF_
     if $RESIZE_DISK
     then
         outputn "Resizing the disk to $DISK_SIZE"
-        qemu-img create -f qcow2 \
-            -o preallocation=metadata $DISK.new $DISK_SIZE &>> ${VMNAME}.log \
-            && virt-resize --quiet --expand /dev/sda1 $DISK $DISK.new &>> ${VMNAME}.log \
-            && (mv $DISK.new $DISK && ok) \
-            || die "Could not resize disk."
+		if [ "${DISTRO}" = "ubuntu1804" ]
+        then
+            qemu-img resize $DISK $DISK_SIZE &>> ${VMNAME}.log \
+                && ok \
+                || die "Could not resize disk."
+		else
+			qemu-img create -f qcow2 \
+				-o preallocation=metadata $DISK.new $DISK_SIZE &>> ${VMNAME}.log \
+				&& virt-resize --quiet --expand /dev/sda1 $DISK $DISK.new &>> ${VMNAME}.log \
+				&& (mv $DISK.new $DISK && ok) \
+				|| die "Could not resize disk."
+		fi
     fi
 
     # Create CD-ROM ISO with cloud-init config

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -484,6 +484,9 @@ _EOF_
     if $RESIZE_DISK
     then
         outputn "Resizing the disk to $DISK_SIZE"
+        # Workaround to prevent virt-resize from renumbering partitions and breaking grub
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1472039
+        # Ubuntu will automatically grow the partition to the new size on its first boot
         if [ "$DISTRO" = "ubuntu1804" ]
         then
             qemu-img resize $DISK $DISK_SIZE &>> ${VMNAME}.log \

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -484,18 +484,18 @@ _EOF_
     if $RESIZE_DISK
     then
         outputn "Resizing the disk to $DISK_SIZE"
-		if [ "${DISTRO}" = "ubuntu1804" ]
+        if [ "${DISTRO}" = "ubuntu1804" ]
         then
             qemu-img resize $DISK $DISK_SIZE &>> ${VMNAME}.log \
                 && ok \
                 || die "Could not resize disk."
-		else
-			qemu-img create -f qcow2 \
-				-o preallocation=metadata $DISK.new $DISK_SIZE &>> ${VMNAME}.log \
-				&& virt-resize --quiet --expand /dev/sda1 $DISK $DISK.new &>> ${VMNAME}.log \
-				&& (mv $DISK.new $DISK && ok) \
-				|| die "Could not resize disk."
-		fi
+        else
+            qemu-img create -f qcow2 \
+                -o preallocation=metadata $DISK.new $DISK_SIZE &>> ${VMNAME}.log \
+                && virt-resize --quiet --expand /dev/sda1 $DISK $DISK.new &>> ${VMNAME}.log \
+                && (mv $DISK.new $DISK && ok) \
+                || die "Could not resize disk."
+        fi
     fi
 
     # Create CD-ROM ISO with cloud-init config

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -484,7 +484,7 @@ _EOF_
     if $RESIZE_DISK
     then
         outputn "Resizing the disk to $DISK_SIZE"
-        if [ "${DISTRO}" = "ubuntu1804" ]
+        if [ "$DISTRO" = "ubuntu1804" ]
         then
             qemu-img resize $DISK $DISK_SIZE &>> ${VMNAME}.log \
                 && ok \


### PR DESCRIPTION
virt-resize changes partition numbering and breaks Ubuntu 18, per this issue: https://github.com/giovtorres/kvm-install-vm/issues/20

This pull request should fix it by just resizing the partition with qemu-img, and relying on Ubuntu growing the partition to the new size on first boot (you can see messages showing that it's been resized in /var/log/syslog).