### PR TITLE
remove pipe to /dev/null

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -503,7 +503,7 @@ _EOF_
 
     # Create CD-ROM ISO with cloud-init config
     outputn "Generating ISO for cloud-init"
-    if [ `which genisoimage &>/dev/null` ]
+    if [ -e `which genisoimage` ]
     then
         genisoimage -output $CI_ISO \
             -volid cidata \


### PR DESCRIPTION
The check for the genisoimage application didn't work.  Piping the output of which to /dev/null results in an empty string, and will always be "false".