### PR TITLE
Fix wrong media eject device

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -583,7 +583,7 @@ _EOF_
     fi
 
     # Eject cdrom
-    virsh change-media ${VMNAME} hda --eject --config &>> ${VMNAME}.log
+    virsh change-media ${VMNAME} sda --eject --config &>> ${VMNAME}.log
 
     # Remove the unnecessary cloud init files
     outputn "Cleaning up cloud-init files"


### PR DESCRIPTION
I detected a wrong return code during a successful `kvm-install-vm` (within a script with `set -e`).
Could track it down to the invalid `virsh change-media ${VMNAME} hda --eject --config &>> ${VMNAME}.log` command (hda seems not to exists).

This should fix it.
Needs testing though on other distros (only tested on Ubuntu 18.04).