### PR TITLE
Avoid rm prompt when cleaning up cloud-init files

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -587,7 +587,7 @@ _EOF_
 
     # Remove the unnecessary cloud init files
     outputn "Cleaning up cloud-init files"
-    rm $USER_DATA $META_DATA $CI_ISO && ok
+    rm -f $USER_DATA $META_DATA $CI_ISO && ok
 
     if [ -f "/var/lib/libvirt/dnsmasq/${BRIDGE}.status" ]
     then


### PR DESCRIPTION
The cloud-init iso file can be created as a read-only file, which causes
the `rm` program to prompt the user to confirm remove.  Use the rm force
option to override this prompt and remove the file.

Example output before this commit:

  $ kvm-install-vm create test01
  - Copying cloud image (CentOS-7-x86_64-GenericCloud.qcow2) ... OK
  - Generating ISO for cloud-init ... OK
  - Creating storage pool ... OK
  - Installing the domain ... OK
  - Enabling autostart ... OK
  - Cleaning up cloud-init files ... rm: remove write-protected regular file 'test01-cidata.iso'? (hangs here)