### PR TITLE
Eject the CI CDROM by image path name

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -583,7 +583,7 @@ _EOF_
     fi
 
     # Eject cdrom
-    virsh change-media ${VMNAME} hda --eject --config &>> ${VMNAME}.log
+    virsh change-media ${VMNAME} --path ${VMDIR}/${VMNAME}/${CI_ISO} --eject --config &>> ${VMNAME}.log
 
     # Remove the unnecessary cloud init files
     outputn "Cleaning up cloud-init files"


### PR DESCRIPTION
Currently the eject command hard-codes device name 'hda' to eject the CI
CDROM image. However the device name depends on the distribution of the
kvm host system.

Fortunately, the 'virsh change-media' command can alternately use the
path of the image instead of the device name, so use that instead of the
hard-coded device name 'hda' to eject the CDROM image.