### PR TITLE
Add -y and -n options for non-interactive support

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -45,25 +45,27 @@ function usage_subcommand ()
             printf "    help - show this help\n"
             printf "\n"
             printf "OPTIONS\n"
-            printf "    -a          Autostart           (default: false)\n"
-            printf "    -b          Bridge              (default: virbr0)\n"
-            printf "    -c          Number of vCPUs     (default: 1)\n"
-            printf "    -d          Disk Size (GB)      (default: 10)\n"
-            printf "    -D          DNS Domain          (default: example.local)\n"
-            printf "    -f          CPU Model / Feature (default: host)\n"
-            printf "    -g          Graphics type       (default: spice)\n"
+            printf "    -a          Autostart             (default: false)\n"
+            printf "    -b          Bridge                (default: virbr0)\n"
+            printf "    -c          Number of vCPUs       (default: 1)\n"
+            printf "    -d          Disk Size (GB)        (default: 10)\n"
+            printf "    -D          DNS Domain            (default: example.local)\n"
+            printf "    -f          CPU Model / Feature   (default: host)\n"
+            printf "    -g          Graphics type         (default: spice)\n"
             printf "    -h          Display help\n"
             printf "    -i          Custom QCOW2 Image\n"
-            printf "    -k          SSH Public Key      (default: $HOME/.ssh/id_rsa.pub)\n"
-            printf "    -l          Location of Images  (default: $HOME/virt/images)\n"
-            printf "    -L          Location of VMs     (default: $HOME/virt/vms)\n"
-            printf "    -m          Memory Size (MB)    (default: 1024)\n"
-            printf "    -M          Mac address         (default: auto-assigned)\n"
-            printf "    -p          Console port        (default: auto)\n"
+            printf "    -k          SSH Public Key        (default: $HOME/.ssh/id_rsa.pub)\n"
+            printf "    -l          Location of Images    (default: $HOME/virt/images)\n"
+            printf "    -L          Location of VMs       (default: $HOME/virt/vms)\n"
+            printf "    -m          Memory Size (MB)      (default: 1024)\n"
+            printf "    -M          Mac address           (default: auto-assigned)\n"
+            printf "    -p          Console port          (default: auto)\n"
             printf "    -s          Custom shell script\n"
-            printf "    -t          Linux Distribution  (default: centos7)\n"
-            printf "    -T          Timezone            (default: US/Eastern)\n"
-            printf "    -u          Custom user         (default: $USER)\n"
+            printf "    -t          Linux Distribution    (default: centos7)\n"
+            printf "    -T          Timezone              (default: US/Eastern)\n"
+            printf "    -u          Custom user           (default: $USER)\n"
+            printf "    -y          Assume yes to prompts (default: false)\n"
+            printf "    -n          Assume no to prompts  (default: false)\n"
             printf "    -v          Be verbose\n"
             printf "\n"
             printf "DISTRIBUTIONS\n"
@@ -680,6 +682,8 @@ function set_defaults ()
     PORT=-1                         # Console port
     TIMEZONE=US/Eastern             # Timezone
     ADDITIONAL_USER=${USER}         # User
+    ASSUME_YES=0                    # Assume yes to prompts
+    ASSUME_NO=0                     # Assume no to prompts
     VERBOSE=0                       # Verbosity
 
     # Reset OPTIND
@@ -698,7 +702,7 @@ function set_custom_defaults ()
 function create ()
 {
     # Parse command line arguments
-    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:ahv" opt
+    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:ahynv" opt
     do
         case "$opt" in
             a ) AUTOSTART=${OPTARG} ;;
@@ -719,6 +723,8 @@ function create ()
             t ) DISTRO="${OPTARG}" ;;
             T ) TIMEZONE="${OPTARG}" ;;
             u ) ADDITIONAL_USER="${OPTARG}" ;;
+            y ) ASSUME_YES=1 ;;
+            n ) ASSUME_NO=1 ;;
             v ) VERBOSE=1 ;;
             h ) usage ;;
             * ) die "Unsupported option. Run 'kvm-install-vm help create'." ;;
@@ -732,6 +738,13 @@ function create ()
     then
         RESIZE_DISK=true
         DISK_SIZE="${DISK_SIZE}G"   # Append 'G' for Gigabyte
+    fi
+
+    # Yes (-y) and No (-n) are mutually exclusive.
+    if [[ "${ASSUME_YES}" -eq 1 ]] && [[ "${ASSUME_NO}" -eq 1 ]]
+    then
+        printf "Please specify only one of -y or -n flags.\n"
+        exit 1
     fi
 
     # After all options are processed, make sure only one variable is left (vmname)
@@ -765,8 +778,16 @@ function create ()
     domain_exists "${VMNAME}"
 
     if [ "${DOMAIN_EXISTS}" -eq 1 ]; then
-        echo -n "[WARNING] ${VMNAME} already exists.  "
-        read -p "Do you want to overwrite ${VMNAME} [y/N]? " -r
+        echo -n "[WARNING] ${VMNAME} already exists.  Do you want to overwrite ${VMNAME} [y/N]? "
+        if [ "${ASSUME_YES}" -eq 1 ]; then
+            REPLY="y"
+            echo $REPLY
+        elif [ "${ASSUME_NO}" -eq 1 ]; then
+            REPLY="n"
+            echo $REPLY
+        else
+            read -r
+        fi
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             remove ${VMNAME}
         else


### PR DESCRIPTION
Add the -y and -n flags to support non-interactive use by assuming 'yes'
or 'no' to the prompt to overwrite the existing domain, if one.