### PR TITLE
Resume interrupted downloads

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -296,10 +296,23 @@ function fetch_images ()
 
     if [ ! -f ${IMAGEDIR}/${QCOW} ]
     then
-        output "Cloud image not found.  Downloading"
         set_wget
-        ${WGET} --directory-prefix ${IMAGEDIR} ${IMAGE_URL}/${QCOW} || \
+        if [ -f ${IMAGEDIR}/${QCOW}.part ]
+        then
+            CONTINUE="--continue"
+            output "Partial cloud image found.  Resuming download"
+        else
+            CONTINUE=""
+            output "Cloud image not found.  Downloading"
+        fi
+        ${WGET} \
+            ${CONTINUE} \
+            --directory-prefix ${IMAGEDIR} \
+            --output-document=${IMAGEDIR}/${QCOW}.part \
+            ${IMAGE_URL}/${QCOW} || \
             die "Could not download image."
+
+        mv ${IMAGEDIR}/${QCOW}.part ${IMAGEDIR}/${QCOW}
     fi
 
 }


### PR DESCRIPTION
Currently, if an image download is interrupted or fails, a partial file
is left in the image directory and a subsequent kvm-install-vm create
command will blissfully use the partial image, which then silently fails
to create the guest.

Instead, name the files with the '.part' file extension while the file
download is in progress, then pivot to the real image name after the
download is complete.  Use the wget '--continue' option to resume
partial downloads so we don't have to restart the download from the
beginning.