### PR TITLE
Allow to add custom USERDATA

### DIFF
--- a/.kivrc
+++ b/.kivrc
@@ -51,5 +51,15 @@
 # User
 #ADDITIONAL_USER=${USER}
 
+# Path to custom USERDATA
+#CUSTOM_USER_DATA=
+
+# Set user password (boolean)
+#PASSWORD=false
+
+# List of plugins. Set the path to the plugin.
+#PLUGIN=("~/plugin1", "~/plugin2", ..)
+
 # Verbosity
 #VERBOSE=0
+

--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ OPTIONS
     -m          Memory Size (MB)    (default: 1024)
     -M          Mac address         (default: auto-assigned)
     -p          Console port        (default: auto)
+    -P          User password       (default: false)
     -s          Custom shell script
     -t          Linux Distribution  (default: centos7)
     -T          Timezone            (default: US/Eastern)
-    -u          Custom user         (defualt: $USER)
+    -u          Custom user         (default: $USER)
+    -U          Custom User Data
     -v          Be verbose
 
 DISTRIBUTIONS

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -209,7 +209,7 @@ function delete_vm ()
     else
         output "Domain ${VMNAME} does not exist"
     fi
-    
+
     [[ -d ${VMDIR}/${VMNAME} ]] && DISKDIR=${VMDIR}/${VMNAME} || DISKDIR=${IMAGEDIR}/${VMNAME}
     [ -d $DISKDIR ] \
         && outputn "Deleting ${VMNAME} files" \
@@ -418,6 +418,15 @@ function check_delete_known_host ()
 
 function create_vm ()
 {
+    # Source plugin
+    if [ -n "${PLUGIN}" ]
+    then
+        for x in "${PLUGIN[@]}"
+        do
+            source "$x"
+        done
+    fi
+
     # Create image directory if it doesn't already exist
     mkdir -p ${VMDIR}
 
@@ -432,9 +441,33 @@ function create_vm ()
     # Create log file
     touch ${VMNAME}.log
 
+    # Create password hash
+    if $PASSWORD
+    then
+        PASSWD_HASH=$(python3 -c "from getpass import getpass; from crypt import *; \
+        p=getpass(); print(crypt(p, METHOD_SHA512).replace('$', '\$')) \
+        if p==getpass('Please repeat: ') else print('\nFailed repeating.')")
+    fi
     # cloud-init config: set hostname, remove cloud-init package,
-    # and add ssh-key
-    cat > $USER_DATA << _EOF_
+    # and add ssh-key; use custom user data if configured.
+    if [ -n "${CUSTOM_USER_DATA}" ]
+    then
+        export \
+            ADDITIONAL_USER \
+            CLOUDINITDISABLE \
+            DNSDOMAIN \
+            KEY \
+            NETRESTART \
+            PASSWD_HASH \
+            SUDOGROUP \
+            TIMEZONE \
+            VMNAME
+        _CUSTOM_USER_DATA=$(envsubst < "${CUSTOM_USER_DATA}")
+        cat > $USER_DATA << _EOF_
+${_CUSTOM_USER_DATA}
+_EOF_
+    else
+        cat > $USER_DATA << _EOF_
 Content-Type: multipart/mixed; boundary="==BOUNDARY=="
 MIME-Version: 1.0
 --==BOUNDARY==
@@ -476,7 +509,7 @@ runcmd:
   - ${NETRESTART}
   - ${CLOUDINITDISABLE}
 _EOF_
-
+    fi
     if [ ! -z "${SCRIPTNAME+x}" ]
     then
         SCRIPT=$(< $SCRIPTNAME)
@@ -695,10 +728,12 @@ function set_defaults ()
     DNSDOMAIN=example.local         # DNS domain
     GRAPHICS=spice                  # Graphics type
     RESIZE_DISK=false               # Resize disk (boolean)
+    PASSWORD=false                  # Resize disk (boolean)
     IMAGEDIR=${HOME}/virt/images    # Directory to store images
     VMDIR=${HOME}/virt/vms          # Directory to store virtual machines
     BRIDGE=virbr0                   # Hypervisor bridge
     PUBKEY=""                       # SSH public key
+    PLUGIN=()                       # List of plugins. Set the path to plugin.
     DISTRO=centos7                  # Distribution
     MACADDRESS=""                   # MAC Address
     PORT=-1                         # Console port
@@ -724,7 +759,7 @@ function set_custom_defaults ()
 function create ()
 {
     # Parse command line arguments
-    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:ahynv" opt
+    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:U:ahynPv" opt
     do
         case "$opt" in
             a ) AUTOSTART=${OPTARG} ;;
@@ -741,10 +776,12 @@ function create ()
             m ) MEMORY="${OPTARG}" ;;
             M ) MACADDRESS="${OPTARG}" ;;
             p ) PORT="${OPTARG}" ;;
+            P ) PASSWORD="true" ;;
             s ) SCRIPTNAME="${OPTARG}" ;;
             t ) DISTRO="${OPTARG}" ;;
             T ) TIMEZONE="${OPTARG}" ;;
             u ) ADDITIONAL_USER="${OPTARG}" ;;
+            U ) CUSTOM_USER_DATA="${OPTARG}" ;;
             y ) ASSUME_YES=1 ;;
             n ) ASSUME_NO=1 ;;
             v ) VERBOSE=1 ;;


### PR DESCRIPTION
## Description
Allow users to add a custom user-data cloud-config. If no user-data has been supplied, then the harcoded user-data is used. 
By default `kvm-install-vm` uses `NOPASSWD` for sudo users. I prefer not to give `NOPASSWD` privileges. Instead I provide a hashed password to cloud-init like so:

## Example
`.kivrc`:
```
USERDATA="${HOME}/custom-user-data"
```

`custom-user-data`
```
#!/bin/bash                                                                                                                                                                                                        
source /home/user/file/enc/password_hash
cat > $USER_DATA << _EOF_                                                                                                                                                                                          
Content-Type: multipart/mixed; boundary="==BOUNDARY=="                                                                                                                                                             
MIME-Version: 1.0                                                                                                                                                                                                  
--==BOUNDARY==                                                                                                                                                                                                     
Content-Type: text/cloud-config; charset="us-ascii"                                                                                                                                                                
                                                                                                                                                                                                                   
#cloud-config                                                                                                                                                                                                      
                                                                                                                                                                                                                   
# Hostname management                                                                                                                                                                                              
preserve_hostname: False                                                                                                                                                                                           
hostname: ${VMNAME}                                                                                                                                                                                                
fqdn: ${VMNAME}.${DNSDOMAIN}                                                                                                                                                                                       
                                                                                                                                                                                                                   
# Users                                                                                                                                                                                                            
users:                                                                                                                                                                                                             
    - default                                                                                                                                                                                                      
    - name: ${ADDITIONAL_USER}                                                                                                                                                                                     
      groups: ['${SUDOGROUP}']                                                                                                                                                                                     
      shell: /bin/bash                                                                                                                                                                                             
      sudo: ALL=(ALL) ALL                                                                                                                                                                                 
      ssh-authorized-keys:                                                                                                                                                                                         
        - ${KEY}                                                                                                                                                                                                   
                                                                                                                                                                                                                   
chpasswd:                                                                                                                                                                                                          
  list: |                                                                                                                                                                                                          
    root:${passwd_hash}                                                                                                                                                                                            
    some-user:${passwd_hash}                                                                                                                                                                                         
  expire: false                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                      
# Configure where output will go                                                                                                                                                                                   
output:                                                                                                                                                                                                            
  all: ">> /var/log/cloud-init.log"                                                                                                                                                                                
                                                                                                                                                                                                                   
# configure interaction with ssh server                                                                                                                                                                            
ssh_genkeytypes: ['ed25519', 'rsa']                                                                                                                                                                                
                                                                                                                                                                                                                   
# Install my public ssh key to the first user-defined user configured                                                                                                                                              
# in cloud.cfg in the template (which is centos for CentOS cloud images)                                                                                                                                           
ssh_authorized_keys:                                                                                                                                                                                               
  - ${KEY}                                                                                                                                                                                                         
                                                                                                                                                                                                                   
timezone: ${TIMEZONE}                                                                                                                                                                                              
                                                                                                                                                                                                                   
# Remove cloud-init when finished with it                                                                                                                                                                          
runcmd:                                                                                                                                                                                                            
  - ${NETRESTART}                                                                                                                                                                                                  
  - ${CLOUDINITDISABLE}                                                                                                                                                                                            
_EOF_   
```
- The hash password can be stored encrypted with `openssl` and decrypted interactively before running `kvm-install-vm`.

### Note
Because the hashes are within a `heredoc` format `$`-sign has to be escaped by a backslash and not single quotes.

Closes #42 