### PR TITLE
Add Fedora 31 support

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -78,6 +78,7 @@ function usage_subcommand ()
             printf "    fedora29        Fedora 29                           fedora\n"
             printf "    fedora29-atomic Fedora 29 Atomic Host               fedora\n"
             printf "    fedora30        Fedora 30                           fedora\n"
+            printf "    fedora31        Fedora 31                           fedora\n"
             printf "    ubuntu1604      Ubuntu 16.04 LTS (Xenial Xerus)     ubuntu\n"
             printf "    ubuntu1804      Ubuntu 18.04 LTS (Bionic Beaver)    ubuntu\n"
             printf "\n"
@@ -261,7 +262,7 @@ function delete_vm ()
     else
         output "Domain ${VMNAME} does not exist"
     fi
-    
+
     [[ -d ${VMDIR}/${VMNAME} ]] && DISKDIR=${VMDIR}/${VMNAME} || DISKDIR=${IMAGEDIR}/${VMNAME}
     [ -d $DISKDIR ] \
         && outputn "Deleting ${VMNAME} files" \
@@ -355,6 +356,14 @@ function fetch_images ()
           OS_TYPE="linux"
           OS_VARIANT="fedora29"
           IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images
+          DISK_FORMAT=qcow2
+          LOGIN_USER=fedora
+          ;;
+        fedora31)
+          QCOW=Fedora-Cloud-Base-31-1.9.x86_64.qcow2
+          OS_TYPE="linux"
+          OS_VARIANT="fedora29"
+          IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images
           DISK_FORMAT=qcow2
           LOGIN_USER=fedora
           ;;

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -278,6 +278,17 @@ function delete_vm ()
     fi
 }
 
+function get_fedora_os_variant()
+{
+    # If $1 is is in osqinfo-query then use that string, otherwise use the
+    # highest matching Fedora variant.
+    if osinfo-query os | grep -q "$1"; then
+        echo "$1"
+        return
+    fi
+    echo "fedora$(osinfo-query os | awk '/fedora/ {print $1}' | grep -Eo '[0-9]+' | sort -nr | head -n1)"
+}
+
 function fetch_images ()
 {
     # Create image directory if it doesn't already exist
@@ -338,7 +349,7 @@ function fetch_images ()
         fedora29)
           QCOW=Fedora-Cloud-Base-29-1.2.x86_64.qcow2
           OS_TYPE="linux"
-          OS_VARIANT="fedora29"
+          OS_VARIANT=$(get_fedora_os_variant fedora29)
           IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images
           DISK_FORMAT=qcow2
           LOGIN_USER=fedora
@@ -346,7 +357,7 @@ function fetch_images ()
         fedora29-atomic)
           QCOW=Fedora-AtomicHost-29-20190611.0.x86_64.qcow2
           OS_TYPE="linux"
-          OS_VARIANT="fedora29"
+          OS_VARIANT=$(get_fedora_os_variant fedora29)
           IMAGE_URL=https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-29-updates-20190611.0/AtomicHost/x86_64/images/
           DISK_FORMAT=qcow2
           LOGIN_USER=fedora
@@ -354,7 +365,7 @@ function fetch_images ()
         fedora30)
           QCOW=Fedora-Cloud-Base-30-1.2.x86_64.qcow2
           OS_TYPE="linux"
-          OS_VARIANT="fedora29"
+          OS_VARIANT=$(get_fedora_os_variant fedora30)
           IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images
           DISK_FORMAT=qcow2
           LOGIN_USER=fedora
@@ -362,7 +373,7 @@ function fetch_images ()
         fedora31)
           QCOW=Fedora-Cloud-Base-31-1.9.x86_64.qcow2
           OS_TYPE="linux"
-          OS_VARIANT="fedora29"
+          OS_VARIANT=$(get_fedora_os_variant fedora31)
           IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images
           DISK_FORMAT=qcow2
           LOGIN_USER=fedora

--- a/tests/check_distributions.bats
+++ b/tests/check_distributions.bats
@@ -49,11 +49,19 @@ function remove_test_vm ()
 }
 
 @test "Install VM (Fedora 30) - $VMNAME-fedora30" {
-    create_test_vm fedora28
+    create_test_vm fedora30
 }
 
 @test "Delete VM (Fedora 30) - $VMNAME-fedora30" {
-    remove_test_vm fedora28
+    remove_test_vm fedora30
+}
+
+@test "Install VM (Fedora 31) - $VMNAME-fedora31" {
+    create_test_vm fedora31
+}
+
+@test "Delete VM (Fedora 31) - $VMNAME-fedora31" {
+    remove_test_vm fedora31
 }
 
 @test "Install VM (Ubuntu 16.04) - $VMNAME-ubuntu1604" {


### PR DESCRIPTION
A few things:
 * Add the URLs for fedora 31, and add the switch statement thing
 * I'm trying to run this script on an older version of Ubuntu that doesn't yet have the fedora29 variant (the latest it has is fedora28). I added some logic to the script to make the os-variant selection logic more robust, it will now pick the highest fedora variant known to the host if the host doesn't know about this version.