### PR TITLE
Add support for openSUSE Leap 15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ DISTRIBUTIONS
     fedora28        Fedora 28                           fedora
     fedora28-atomic Fedora 28 Atomic Host               fedora
     fedora31        Fedora 31                           fedora
+    opensuse15      OpenSUSE Leap 15.2                  opensuse
     ubuntu1604      Ubuntu 16.04 LTS (Xenial Xerus)     ubuntu
     ubuntu1804      Ubuntu 18.04 LTS (Bionic Beaver)    ubuntu
 

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -80,6 +80,7 @@ function usage_subcommand ()
             printf "    fedora29-atomic Fedora 29 Atomic Host               fedora\n"
             printf "    fedora30        Fedora 30                           fedora\n"
             printf "    fedora31        Fedora 31                           fedora\n"
+            printf "    opensuse15      OpenSUSE Leap 15.2                  opensuse\n"
             printf "    ubuntu1604      Ubuntu 16.04 LTS (Xenial Xerus)     ubuntu\n"
             printf "    ubuntu1804      Ubuntu 18.04 LTS (Bionic Beaver)    ubuntu\n"
             printf "\n"
@@ -392,6 +393,14 @@ function fetch_images ()
             DISK_FORMAT=qcow2
             LOGIN_USER=ubuntu
             ;;
+        opensuse15)
+            QCOW=openSUSE-Leap-15.2-OpenStack.x86_64.qcow2
+            OS_TYPE="linux"
+            OS_VARIANT="auto"
+            IMAGE_URL=https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images
+            DISK_FORMAT=qcow2
+            LOGIN_USER=opensuse
+            ;;
         *)
             die "${DISTRO} not a supported OS.  Run 'kvm-install-vm create help'."
             ;;
@@ -463,7 +472,7 @@ function storpool_exists ()
 function set_sudo_group ()
 {
     case "${DISTRO}" in
-        centos?|fedora??|*-atomic|amazon? )
+        centos?|fedora??|*-atomic|amazon?|opensuse* )
             SUDOGROUP="wheel"
             ;;
         ubuntu*|debian? )
@@ -481,7 +490,7 @@ function set_cloud_init_remove ()
         centos6 )
             CLOUDINITDISABLE="chkconfig cloud-init off"
             ;;
-        centos8|centos7|amazon?|fedora??|ubuntu*|debian? )
+        centos8|centos7|amazon?|fedora??|ubuntu*|debian?|opensuse* )
             CLOUDINITDISABLE="systemctl disable cloud-init.service"
             ;;
         *-atomic)

--- a/tests/check_distributions.bats
+++ b/tests/check_distributions.bats
@@ -95,3 +95,11 @@ function remove_test_vm ()
 @test "Delete VM (Debian 9) - $VMNAME-debian9" {
     remove_test_vm debian9
 }
+
+@test "Install VM (openSUSE Leap 15) - $VMNAME-opensuse15" {
+    create_test_vm opensuse15
+}
+
+@test "Delete VM (openSUSE Leap 15) - $VMNAME-opensuse15" {
+    remove_test_vm opensuse15
+}


### PR DESCRIPTION
Add support for openSUSE using the most recent openSUSE Leap cloud image
provided by the openSUSE build service.