### PR TITLE
Always print MAC address for created VM

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -718,10 +718,12 @@ _EOF_
     outputn "Cleaning up cloud-init files"
     rm -f $USER_DATA $META_DATA $CI_ISO && ok
 
+    MAC=$(virsh dumpxml ${VMNAME} | awk -F\' '/mac address/ {print $2}')
+    output "MAC address: ${MAC}"
+
     if [ -f "/var/lib/libvirt/dnsmasq/${BRIDGE}.status" ]
     then
         outputn "Waiting for domain to get an IP address"
-        MAC=$(virsh dumpxml ${VMNAME} | awk -F\' '/mac address/ {print $2}')
         while true
         do
             IP=$(grep -B1 $MAC /var/lib/libvirt/dnsmasq/$BRIDGE.status | head \


### PR DESCRIPTION
It's useful in case if you're using bridge or IP address can't be obtained for some other reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/giovtorres/kvm-install-vm/52)
<!-- Reviewable:end -->
