### PR TITLE
Check os-variant before starting vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ Options are evaluated in the following order:
    same host and its hostname will likely not resolve until the old lease
    expires.
 
+3. The Operating System information database (osinfo-db) provides Operating
+   System specific information needed to create guests for the various systems
+   supported by `kvm-install-vm`.  The database files provided by your package
+   manager may be out of date and not provide definitions for recent Operating
+   System versions. If you encounter the following error message, you may need
+   to update the database files:
+   `ERR: Unknown OS variant '<name>'. Please update your osinfo-db.`
+   If you have already updated your system, and the osinfo-db is still to old,
+   then you can use the `osinfo-db-import` tool with the `--local` option, to
+   install an up-to-date database in your home directory which will not
+   conflict with your package manager files. The `osinfo-db-import` tool is
+   provided by the rpm/deb packages `osinfo-db-tools`.
+   See https://libosinfo.org/download for more information.
+
 ### Testing
 
 Tests are written using [Bats](https://github.com/sstephenson/bats).  To

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -455,6 +455,15 @@ function check_ssh_key ()
     fi
 }
 
+function check_os_variant ()
+{
+    if [[ ${OS_VARIANT} != auto ]]; then
+        osinfo-query os short-id=${OS_VARIANT} >/dev/null \
+            || die "Unknown OS variant '${OS_VARIANT}'. Please update your osinfo-db. "\
+                   "See https://libosinfo.org/download for more information."
+    fi
+}
+
 function domain_exists ()
 {
     virsh dominfo "${1}" > /dev/null 2>&1 \
@@ -909,6 +918,9 @@ function create ()
     else
         fetch_images
     fi
+
+    # Verify the osinfo-db is up to date.
+    check_os_variant
 
     # Check if domain already exists
     domain_exists "${VMNAME}"


### PR DESCRIPTION
Check the osinfo-db is not too old, and if so issue an error message to
explain how to upgrade the osinfo-db.

The osinfo-db provided by package managers tend to lag the upstream
libosinfo project. This makes it harder to support new os versions when
your kvm is running on something like CentOS or Ubuntu LTS.  Fortunately
the libosinfo project provides downloads and a tool to import the
osinfo-db without impacting the files managed by the package manager,
which makes using kvm-import-vm create a much more pleasant experience.