### PR TITLE
Add custom user data

### DIFF
--- a/.kivrc
+++ b/.kivrc
@@ -51,6 +51,12 @@
 # User
 #ADDITIONAL_USER=${USER}
 
+# Path to custom USERDATA
+#CUSTOM_USER_DATA=
+
+# Enable user password (boolean)
+#PASSWORD=false
+
 # Verbosity
 #VERBOSE=0
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You need to have the KVM hypervisor installed, along with a few other packages:
 - libguestfs-tools-c
 - qemu-img
 - libvirt-client
+- python3
 
 To install the dependencies, run:
 
@@ -66,25 +67,28 @@ DESCRIPTION
     Create a new guest domain.
 
 OPTIONS
-    -a          Autostart           (default: false)
-    -b          Bridge              (default: virbr0)
-    -c          Number of vCPUs     (default: 1)
-    -d          Disk Size (GB)      (default: 10)
-    -D          DNS Domain          (default: example.local)
-    -f          CPU Model / Feature (default: host)
-    -g          Graphics type       (default: spice)
+    -a          Autostart            (default: false)
+    -b          Bridge               (default: virbr0)
+    -c          Number of vCPUs      (default: 1)
+    -d          Disk Size (GB)       (default: 10)
+    -D          DNS Domain           (default: example.local)
+    -f          CPU Model / Feature  (default: host)
+    -g          Graphics type        (default: spice)
     -h          Display help
     -i          Custom QCOW2 Image
-    -k          SSH Public Key      (default: $HOME/.ssh/id_rsa.pub)
-    -l          Location of Images  (default: $HOME/virt/images)
-    -L          Location of VMs     (default: $HOME/virt/vms)
-    -m          Memory Size (MB)    (default: 1024)
-    -M          Mac address         (default: auto-assigned)
-    -p          Console port        (default: auto)
+    -k          SSH Public Key       (default: $HOME/.ssh/id_rsa.pub)
+    -l          Location of Images   (default: $HOME/virt/images)
+    -L          Location of VMs      (default: $HOME/virt/vms)
+    -m          Memory Size (MB)     (default: 1024)
+    -M          Mac address          (default: auto-assigned)
+    -p          Console port         (default: auto)
+    -P          Enable User password (default: false)
     -s          Custom shell script
-    -t          Linux Distribution  (default: centos8)
-    -T          Timezone            (default: US/Eastern)
-    -u          Custom user         (defualt: $USER)
+    -t          Linux Distribution   (default: centos8)
+    -T          Timezone             (default: US/Eastern)
+    -u          Custom user          (defualt: $USER)
+    -u          Custom user          (default: $USER)
+    -U          Custom User Data
     -v          Be verbose
 
 DISTRIBUTIONS

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ DISTRIBUTIONS
     centos6         CentOS 6                            centos
     centos8         CentOS 8                            centos
     debian9         Debian 9 (Stretch)                  debian
+    debian10        Debian 10 (Buster)                  debian
     fedora27        Fedora 27                           fedora
     fedora27-atomic Fedora 27 Atomic Host               fedora
     fedora28        Fedora 28                           fedora

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -569,11 +569,14 @@ function create_vm ()
     # Create log file
     touch ${VMNAME}.log
 
-    if $PASSWORD
+    if $PASSWORD && command -v python3 >/dev/null
     then
         PASSWD_HASH=$(python3 -c "from getpass import getpass; from crypt import *; \
         p=getpass(); print(crypt(p, METHOD_SHA512).replace('$', '\$')) \
         if p==getpass('Please repeat: ') else print('\nFailed repeating.')")
+    elif $PASSWORD
+    then
+        echo "Failed to generate a password, because python3 is not installed."
     fi
 
     # cloud-init config: set hostname, remove cloud-init package,

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -537,6 +537,15 @@ function check_delete_known_host ()
 
 function create_vm ()
 {
+    # Source plugin
+    if [ -n "${PLUGIN}" ]
+    then
+        for x in "${PLUGIN[@]}"
+        do
+            source "$x"
+        done
+    fi
+
     # Create image directory if it doesn't already exist
     mkdir -p ${VMDIR}
 
@@ -551,9 +560,34 @@ function create_vm ()
     # Create log file
     touch ${VMNAME}.log
 
+    if $PASSWORD
+    then
+        PASSWD_HASH=$(python3 -c "from getpass import getpass; from crypt import *; \
+        p=getpass(); print(crypt(p, METHOD_SHA512).replace('$', '\$')) \
+        if p==getpass('Please repeat: ') else print('\nFailed repeating.')")
+    fi
+
     # cloud-init config: set hostname, remove cloud-init package,
     # and add ssh-key
-    cat > $USER_DATA << _EOF_
+    # and add ssh-key; use custom user data if configured.
+    if [ -n "${CUSTOM_USER_DATA}" ]
+    then
+        export \
+            ADDITIONAL_USER \
+            CLOUDINITDISABLE \
+            DNSDOMAIN \
+            KEY \
+            NETRESTART \
+            PASSWD_HASH \
+            SUDOGROUP \
+            TIMEZONE \
+            VMNAME
+        _CUSTOM_USER_DATA=$(envsubst < "${CUSTOM_USER_DATA}")
+        cat > $USER_DATA << _EOF_
+${_CUSTOM_USER_DATA}
+_EOF_
+    else
+        cat > $USER_DATA << _EOF_
 Content-Type: multipart/mixed; boundary="==BOUNDARY=="
 MIME-Version: 1.0
 --==BOUNDARY==
@@ -595,7 +629,7 @@ runcmd:
   - ${NETRESTART}
   - ${CLOUDINITDISABLE}
 _EOF_
-
+    fi
     if [ ! -z "${SCRIPTNAME+x}" ]
     then
         SCRIPT=$(< $SCRIPTNAME)
@@ -818,10 +852,12 @@ function set_defaults ()
     DNSDOMAIN=example.local         # DNS domain
     GRAPHICS=spice                  # Graphics type or "auto"
     RESIZE_DISK=false               # Resize disk (boolean)
+    PASSWORD=false                  # Use password (boolean)
     IMAGEDIR=${HOME}/virt/images    # Directory to store images
     VMDIR=${HOME}/virt/vms          # Directory to store virtual machines
     BRIDGE=virbr0                   # Hypervisor bridge
     PUBKEY=""                       # SSH public key
+    PLUGIN=()                       # List of plugins. Set the path to plugin.
     DISTRO=centos8                  # Distribution
     MACADDRESS=""                   # MAC Address
     PORT=-1                         # Console port
@@ -858,7 +894,7 @@ function set_custom_defaults ()
 function create ()
 {
     # Parse command line arguments
-    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:ahynv" opt
+    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:U:ahynPv" opt
     do
         case "$opt" in
             a ) AUTOSTART=${OPTARG} ;;
@@ -875,10 +911,12 @@ function create ()
             m ) MEMORY="${OPTARG}" ;;
             M ) MACADDRESS="${OPTARG}" ;;
             p ) PORT="${OPTARG}" ;;
+            P ) PASSWORD="true" ;;
             s ) SCRIPTNAME="${OPTARG}" ;;
             t ) DISTRO="${OPTARG}" ;;
             T ) TIMEZONE="${OPTARG}" ;;
             u ) ADDITIONAL_USER="${OPTARG}" ;;
+            U ) CUSTOM_USER_DATA="${OPTARG}" ;;
             y ) ASSUME_YES=1 ;;
             n ) ASSUME_NO=1 ;;
             v ) VERBOSE=1 ;;

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -76,6 +76,7 @@ function usage_subcommand ()
             printf "    centos7-atomic  CentOS 7 Atomic Host                centos\n"
             printf "    centos6         CentOS 6                            centos\n"
             printf "    debian9         Debian 9 (Stretch)                  debian\n"
+            printf "    debian10        Debian 10 (Buster)                  debian\n"
             printf "    fedora29        Fedora 29                           fedora\n"
             printf "    fedora29-atomic Fedora 29 Atomic Host               fedora\n"
             printf "    fedora30        Fedora 30                           fedora\n"
@@ -345,6 +346,14 @@ function fetch_images ()
             DISK_FORMAT=qcow2
             LOGIN_USER=debian
             ;;
+        debian10)
+            QCOW=debian-10-openstack-amd64.qcow2
+            OS_TYPE="linux"
+            OS_VARIANT="debian10"
+            IMAGE_URL=https://cdimage.debian.org/cdimage/openstack/current-10
+            DISK_FORMAT=qcow2
+            LOGIN_USER=debian
+            ;;
         fedora29)
           QCOW=Fedora-Cloud-Base-29-1.2.x86_64.qcow2
           OS_TYPE="linux"
@@ -396,7 +405,7 @@ function fetch_images ()
         opensuse15)
             QCOW=openSUSE-Leap-15.2-OpenStack.x86_64.qcow2
             OS_TYPE="linux"
-            OS_VARIANT="auto"
+            OS_VARIANT="opensuse15.0"
             IMAGE_URL=https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images
             DISK_FORMAT=qcow2
             LOGIN_USER=opensuse
@@ -484,7 +493,7 @@ function set_sudo_group ()
         centos?|fedora??|*-atomic|amazon?|opensuse* )
             SUDOGROUP="wheel"
             ;;
-        ubuntu*|debian? )
+        ubuntu*|debian* )
             SUDOGROUP="sudo"
             ;;
         *)
@@ -499,7 +508,7 @@ function set_cloud_init_remove ()
         centos6 )
             CLOUDINITDISABLE="chkconfig cloud-init off"
             ;;
-        centos8|centos7|amazon?|fedora??|ubuntu*|debian?|opensuse* )
+        centos8|centos7|amazon?|fedora??|ubuntu*|debian*|opensuse* )
             CLOUDINITDISABLE="systemctl disable cloud-init.service"
             ;;
         *-atomic)
@@ -512,7 +521,7 @@ function set_network_restart_cmd ()
 {
     case "${DISTRO}" in
         centos6 )           NETRESTART="service network stop && service network start" ;;
-        ubuntu*|debian?)    NETRESTART="systemctl stop networking && systemctl start networking" ;;
+        ubuntu*|debian*)    NETRESTART="systemctl stop networking && systemctl start networking" ;;
         *)                  NETRESTART="systemctl stop network && systemctl start network" ;;
     esac
 }

--- a/tests/check_distributions.bats
+++ b/tests/check_distributions.bats
@@ -96,6 +96,14 @@ function remove_test_vm ()
     remove_test_vm debian9
 }
 
+@test "Install VM (Debian 10) - $VMNAME-debian10" {
+    create_test_vm debian10
+}
+
+@test "Delete VM (Debian 10) - $VMNAME-debian10" {
+    remove_test_vm debian10
+}
+
 @test "Install VM (openSUSE Leap 15) - $VMNAME-opensuse15" {
     create_test_vm opensuse15
 }


### PR DESCRIPTION
As requested I manually updated the changes to the master branch and create a new pull request.

Allow to add custom USERDATA #42
Allow users to add a custom user-data cloud-config. If no user-data has been supplied, then the harcoded user-data is used.
By default kvm-install-vm uses NOPASSWD for sudo users. I prefer not to give NOPASSWD privileges. Instead I provide a hashed password to cloud-init