### PR TITLE
Implement qcow2 backing file feature

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -627,7 +627,7 @@ _EOF_
 
     outputn "Copying cloud image ($(basename ${IMAGE}))"
     DISK=${VMNAME}.qcow2
-    qemu-img create -q -f qcow2 -F qcow2 -b $IMAGE $DISK 10G && ok
+    qemu-img create -q -f qcow2 -F qcow2 -b $IMAGE $DISK && ok
     if $RESIZE_DISK
     then
         outputn "Resizing the disk to $DISK_SIZE"

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -627,7 +627,7 @@ _EOF_
 
     outputn "Copying cloud image ($(basename ${IMAGE}))"
     DISK=${VMNAME}.qcow2
-    cp $IMAGE $DISK && ok
+    qemu-img create -f qcow2 -F qcow2 -b $IMAGE $DISK && ok
     if $RESIZE_DISK
     then
         outputn "Resizing the disk to $DISK_SIZE"

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -627,7 +627,7 @@ _EOF_
 
     outputn "Copying cloud image ($(basename ${IMAGE}))"
     DISK=${VMNAME}.qcow2
-    qemu-img create -f qcow2 -F qcow2 -b $IMAGE $DISK && ok
+    qemu-img create -q -f qcow2 -F qcow2 -b $IMAGE $DISK 10G && ok
     if $RESIZE_DISK
     then
         outputn "Resizing the disk to $DISK_SIZE"


### PR DESCRIPTION
Currently when creating new vm, the base image will be copied with `cp` command, making the new vm disk has same size as the base image. I think it's better to use qcow2 backing file feature, so new disk image will only take spaces for the differences from the base image.