### PR TITLE
Fix ubuntu2004 disk resize

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -634,18 +634,20 @@ _EOF_
         # Workaround to prevent virt-resize from renumbering partitions and breaking grub
         # See https://bugzilla.redhat.com/show_bug.cgi?id=1472039
         # Ubuntu will automatically grow the partition to the new size on its first boot
-        if [[ "$DISTRO" = "ubuntu1804" ]] || [[ "$DISTRO" = "amazon2" ]]
-        then
+        case "$DISTRO" in
+        ubuntu*|amazon2)
             qemu-img resize $DISK $DISK_SIZE &>> ${VMNAME}.log \
                 && ok \
                 || die "Could not resize disk."
-        else
+            ;;
+        *)
             qemu-img create -f qcow2 \
                 -o preallocation=metadata $DISK.new $DISK_SIZE &>> ${VMNAME}.log \
                 && virt-resize --quiet --expand /dev/sda1 $DISK $DISK.new &>> ${VMNAME}.log \
                 && (mv $DISK.new $DISK && ok) \
                 || die "Could not resize disk."
-        fi
+            ;;
+        esac
     fi
 
     # Create CD-ROM ISO with cloud-init config


### PR DESCRIPTION
Use the `qemu-img resize` command to resize ubuntu 20.04, as is done for
ubuntu 18.04  This fixes the error on boot:

   Booting form Hard Disk...
   error: unknown filesystem.
   Entering resue mode...
   grub rescue>

Also use `qemu-img resize` on ubuntu 16.04, so all versions of ubuntu
use this method.