### PR TITLE
Added Fedora 32 to list of distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,47 +77,52 @@ COMMANDS
 ```
 $ kvm-install-vm help create
 NAME
-    kvm-install-vm create [OPTIONS] VMNAME
+    kvm-install-vm create [COMMANDS] [OPTIONS] VMNAME
 
 DESCRIPTION
     Create a new guest domain.
 
+COMMANDS
+    help - show this help
+
 OPTIONS
-    -a          Autostart           (default: false)
-    -b          Bridge              (default: virbr0)
-    -c          Number of vCPUs     (default: 1)
-    -d          Disk Size (GB)      (default: 10)
-    -D          DNS Domain          (default: example.local)
-    -f          CPU Model / Feature (default: host)
-    -g          Graphics type       (default: spice)
+    -a          Autostart             (default: false)
+    -b          Bridge                (default: virbr0)
+    -c          Number of vCPUs       (default: 1)
+    -d          Disk Size (GB)        (default: 10)
+    -D          DNS Domain            (default: example.local)
+    -f          CPU Model / Feature   (default: host)
+    -g          Graphics type         (default: spice)
     -h          Display help
     -i          Custom QCOW2 Image
-    -k          SSH Public Key      (default: $HOME/.ssh/id_rsa.pub)
-    -l          Location of Images  (default: $HOME/virt/images)
-    -L          Location of VMs     (default: $HOME/virt/vms)
-    -m          Memory Size (MB)    (default: 1024)
-    -M          Mac address         (default: auto-assigned)
-    -p          Console port        (default: auto)
+    -k          SSH Public Key        (default: $HOME/.ssh/id_rsa.pub)
+    -l          Location of Images    (default: $HOME/virt/images)
+    -L          Location of VMs       (default: $HOME/virt/vms)
+    -m          Memory Size (MB)      (default: 1024)
+    -M          Mac address           (default: auto-assigned)
+    -p          Console port          (default: auto)
     -s          Custom shell script
-    -t          Linux Distribution  (default: centos8)
-    -T          Timezone            (default: US/Eastern)
-    -u          Custom user         (defualt: $USER)
+    -t          Linux Distribution    (default: centos8)
+    -T          Timezone              (default: US/Eastern)
+    -u          Custom user           (default: $USER)
+    -y          Assume yes to prompts (default: false)
+    -n          Assume no to prompts  (default: false)
     -v          Be verbose
 
 DISTRIBUTIONS
     NAME            DESCRIPTION                         LOGIN
     amazon2         Amazon Linux 2                      ec2-user
+    centos8         CentOS 8                            centos
     centos7         CentOS 7                            centos
     centos7-atomic  CentOS 7 Atomic Host                centos
     centos6         CentOS 6                            centos
-    centos8         CentOS 8                            centos
     debian9         Debian 9 (Stretch)                  debian
     debian10        Debian 10 (Buster)                  debian
-    fedora27        Fedora 27                           fedora
-    fedora27-atomic Fedora 27 Atomic Host               fedora
-    fedora28        Fedora 28                           fedora
-    fedora28-atomic Fedora 28 Atomic Host               fedora
+    fedora29        Fedora 29                           fedora
+    fedora29-atomic Fedora 29 Atomic Host               fedora
+    fedora30        Fedora 30                           fedora
     fedora31        Fedora 31                           fedora
+    fedora32        Fedora 32                           fedora
     opensuse15      OpenSUSE Leap 15.2                  opensuse
     ubuntu1604      Ubuntu 16.04 LTS (Xenial Xerus)     ubuntu
     ubuntu1804      Ubuntu 18.04 LTS (Bionic Beaver)    ubuntu
@@ -125,7 +130,7 @@ DISTRIBUTIONS
 
 EXAMPLES
     kvm-install-vm create foo
-        Create VM with the default parameters: CentOS 7, 1 vCPU, 1GB RAM, 10GB
+        Create VM with the default parameters: CentOS 8, 1 vCPU, 1GB RAM, 10GB
         disk capacity.
 
     kvm-install-vm create -c 2 -m 2048 -d 20 foo
@@ -137,10 +142,6 @@ EXAMPLES
 
     kvm-install-vm create -T UTC foo
         Create a default VM with UTC timezone.
-
-    kvm-install-vm create -s ~/script.sh -g vnc -u bar foo
-        Create a VM with a custom script included in user-data, a graphical
-        console accessible over VNC, and a user named 'bar'.
 ```
 
 #### Deleting a Guest Domain

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -81,6 +81,7 @@ function usage_subcommand ()
             printf "    fedora29-atomic Fedora 29 Atomic Host               fedora\n"
             printf "    fedora30        Fedora 30                           fedora\n"
             printf "    fedora31        Fedora 31                           fedora\n"
+            printf "    fedora32        Fedora 32                           fedora\n"
             printf "    opensuse15      OpenSUSE Leap 15.2                  opensuse\n"
             printf "    ubuntu1604      Ubuntu 16.04 LTS (Xenial Xerus)     ubuntu\n"
             printf "    ubuntu1804      Ubuntu 18.04 LTS (Bionic Beaver)    ubuntu\n"
@@ -384,6 +385,14 @@ function fetch_images ()
           OS_TYPE="linux"
           OS_VARIANT="fedora31"
           IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images
+          DISK_FORMAT=qcow2
+          LOGIN_USER=fedora
+          ;;
+       fedora32)
+          QCOW=Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+          OS_TYPE="linux"
+          OS_VARIANT="fedora32"
+          IMAGE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images
           DISK_FORMAT=qcow2
           LOGIN_USER=fedora
           ;;

--- a/tests/check_distributions.bats
+++ b/tests/check_distributions.bats
@@ -72,6 +72,14 @@ function remove_test_vm ()
     remove_test_vm fedora31
 }
 
+@test "Install VM (Fedora 32) - $VMNAME-fedora32" {
+    create_test_vm fedora32
+}
+
+@test "Delete VM (Fedora 32) - $VMNAME-fedora32" {
+    remove_test_vm fedora32
+}
+
 @test "Install VM (Ubuntu 16.04) - $VMNAME-ubuntu1604" {
     create_test_vm ubuntu1604
 }


### PR DESCRIPTION
Fedora 32 was released a few months ago, so just quickly adding support.

Not sure if you'd prefer the example output of `kvm-install-vm help create` in `README.md` to match the tools current help, as it seems a few older distro versions have been removed since it was last updated.

Just to confirm it's working:
```
$ ./kvm-install-vm create -t fedora32 fedora32-test-vm
- Copying cloud image (Fedora-Cloud-Base-32-1.6.x86_64.qcow2) ... OK
- Resizing the disk to 20G ... OK
- Generating ISO for cloud-init ... OK
- Creating storage pool ... OK
- Installing the domain ... OK
- Cleaning up cloud-init files ... OK
- MAC address: 52:54:00:03:f0:ad
- Waiting for domain to get an IP address ... OK

- Checking for 192.168.122.151 in known_hosts file
- No entries found for 192.168.122.151

- SSH to fedora32-test-vm: 'ssh fedora@192.168.122.151' or 'ssh fedora@fedora32-test-vm'
- Console at spice://localhost:5901
- DONE
```