### PR TITLE
Add support for named networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ OPTIONS
     -L          Location of VMs       (default: $HOME/virt/vms)
     -m          Memory Size (MB)      (default: 1024)
     -M          Mac address           (default: auto-assigned)
+    -n          Network name          (default: none)
     -p          Console port          (default: auto)
     -s          Custom shell script
     -t          Linux Distribution    (default: centos8)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ OPTIONS
     -L          Location of VMs     (default: $HOME/virt/vms)
     -m          Memory Size (MB)    (default: 1024)
     -M          Mac address         (default: auto-assigned)
+    -n          Network name
     -p          Console port        (default: auto)
     -s          Custom shell script
     -t          Linux Distribution  (default: centos7)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ OPTIONS
     -L          Location of VMs       (default: $HOME/virt/vms)
     -m          Memory Size (MB)      (default: 1024)
     -M          Mac address           (default: auto-assigned)
-    -n          Network name          (default: none)
+    -n          Network name          (default: none, overrides -b parameter)
     -p          Console port          (default: auto)
     -s          Custom shell script
     -t          Linux Distribution    (default: centos8)

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -59,7 +59,7 @@ function usage_subcommand ()
             printf "    -L          Location of VMs       (default: $HOME/virt/vms)\n"
             printf "    -m          Memory Size (MB)      (default: 1024)\n"
             printf "    -M          Mac address           (default: auto-assigned)\n"
-            printf "    -n          Network name\n"
+            printf "    -n          Network name          (default: none, overrides -b parameter)\n"
             printf "    -p          Console port          (default: auto)\n"
             printf "    -s          Custom shell script\n"
             printf "    -t          Linux Distribution    (default: centos8)\n"

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -618,15 +618,22 @@ _EOF_
         --target=${VMDIR}/${VMNAME} \
         || die "Could not create storage pool."
 
-    # Add custom MAC Address if specified
-    NETWORK_PARAMS=$(param network ${NETWORK_NAME})
-    if [ -z "${NETWORK_PARAMS}" ]; then
-        NETWORK_PARAMS="$(join ',' \
-            $(param bridge ${BRIDGE}) \
-            $(param model ${NETWORK_MODEL}) \
-            $(param mac ${MACADDRESS}) \
-            ${NETWORK_EXTRA})"
+    if [ -n "${NETWORK_NAME}" ]
+    then
+        NETWORK_PARAMS="$(param network ${NETWORK_NAME})"
+    elif [ -n "${BRIDGE}" ]
+    then
+        NETWORK_PARAMS="$(param bridge ${BRIDGE})"
+    else
+        NETWORK_PARAMS="none"
     fi
+    
+    # Add custom MAC Address if specified
+    NETWORK_PARAMS="$(join ',' \
+        ${NETWORK_PARAMS} \
+        $(param model ${NETWORK_MODEL}) \
+        $(param mac ${MACADDRESS}) \
+        ${NETWORK_EXTRA})"
 
     # Assemble disk parameters.
     DISK_PARAMS="$(join ',' \
@@ -695,7 +702,7 @@ _EOF_
     outputn "Cleaning up cloud-init files"
     rm -f $USER_DATA $META_DATA $CI_ISO && ok
 
-    if [ ! -z "${NETWORK_NAME}" ]; then
+    if [ -n "${NETWORK_NAME}" ]; then
         BRIDGE=$(virsh net-dumpxml "${NETWORK_NAME}" | awk -F\' '/bridge/ {print $2}')
     fi
 

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -683,15 +683,22 @@ _EOF_
         --target=${VMDIR}/${VMNAME} \
         || die "Could not create storage pool."
 
-    # Add custom MAC Address if specified
-    NETWORK_PARAMS=$(param network ${NETWORK_NAME})
-    if [ -z "${NETWORK_PARAMS}" ]; then
-        NETWORK_PARAMS="$(join ',' \
-            $(param bridge ${BRIDGE}) \
-            $(param model ${NETWORK_MODEL}) \
-            $(param mac ${MACADDRESS}) \
-            ${NETWORK_EXTRA})"
+    if [ -n "${NETWORK_NAME}" ]
+    then
+        NETWORK_PARAMS="$(param network ${NETWORK_NAME})"
+    elif [ -n "${BRIDGE}" ]
+    then
+        NETWORK_PARAMS="$(param bridge ${BRIDGE})"
+    else
+        NETWORK_PARAMS="none"
     fi
+    
+    # Add custom MAC Address if specified
+    NETWORK_PARAMS="$(join ',' \
+        ${NETWORK_PARAMS} \
+        $(param model ${NETWORK_MODEL}) \
+        $(param mac ${MACADDRESS}) \
+        ${NETWORK_EXTRA})"
 
     # Assemble disk parameters.
     DISK_PARAMS="$(join ',' \
@@ -762,7 +769,7 @@ _EOF_
     MAC=$(virsh dumpxml ${VMNAME} | awk -F\' '/mac address/ {print $2}')
     output "MAC address: ${MAC}"
     
-    if [ ! -z "${NETWORK_NAME}" ]; then
+    if [ -n "${NETWORK_NAME}" ]; then
         BRIDGE=$(virsh net-dumpxml "${NETWORK_NAME}" | awk -F\' '/bridge/ {print $2}')
     fi
 

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -59,6 +59,7 @@ function usage_subcommand ()
             printf "    -L          Location of VMs       (default: $HOME/virt/vms)\n"
             printf "    -m          Memory Size (MB)      (default: 1024)\n"
             printf "    -M          Mac address           (default: auto-assigned)\n"
+            printf "    -n          Network name\n"
             printf "    -p          Console port          (default: auto)\n"
             printf "    -s          Custom shell script\n"
             printf "    -t          Linux Distribution    (default: centos8)\n"
@@ -683,11 +684,14 @@ _EOF_
         || die "Could not create storage pool."
 
     # Add custom MAC Address if specified
-    NETWORK_PARAMS="$(join ',' \
-        $(param bridge ${BRIDGE}) \
-        $(param model ${NETWORK_MODEL}) \
-        $(param mac ${MACADDRESS}) \
-        ${NETWORK_EXTRA})"
+    NETWORK_PARAMS=$(param network ${NETWORK_NAME})
+    if [ -z "${NETWORK_PARAMS}" ]; then
+        NETWORK_PARAMS="$(join ',' \
+            $(param bridge ${BRIDGE}) \
+            $(param model ${NETWORK_MODEL}) \
+            $(param mac ${MACADDRESS}) \
+            ${NETWORK_EXTRA})"
+    fi
 
     # Assemble disk parameters.
     DISK_PARAMS="$(join ',' \
@@ -757,6 +761,10 @@ _EOF_
 
     MAC=$(virsh dumpxml ${VMNAME} | awk -F\' '/mac address/ {print $2}')
     output "MAC address: ${MAC}"
+    
+    if [ ! -z "${NETWORK_NAME}" ]; then
+        BRIDGE=$(virsh net-dumpxml "${NETWORK_NAME}" | awk -F\' '/bridge/ {print $2}')
+    fi
 
     if [ -f "/var/lib/libvirt/dnsmasq/${BRIDGE}.status" ]
     then
@@ -876,7 +884,7 @@ function set_custom_defaults ()
 function create ()
 {
     # Parse command line arguments
-    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:ahynv" opt
+    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:n:p:s:t:T:u:ahynv" opt
     do
         case "$opt" in
             a ) AUTOSTART=${OPTARG} ;;
@@ -892,6 +900,7 @@ function create ()
             L ) VMDIR="${OPTARG}" ;;
             m ) MEMORY="${OPTARG}" ;;
             M ) MACADDRESS="${OPTARG}" ;;
+            n ) NETWORK_NAME="${OPTARG}" ;;
             p ) PORT="${OPTARG}" ;;
             s ) SCRIPTNAME="${OPTARG}" ;;
             t ) DISTRO="${OPTARG}" ;;

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -770,7 +770,7 @@ _EOF_
     output "MAC address: ${MAC}"
     
     if [ -n "${NETWORK_NAME}" ]; then
-        BRIDGE=$(virsh net-dumpxml "${NETWORK_NAME}" | awk -F\' '/bridge/ {print $2}')
+        BRIDGE=$(virsh net-info "${NETWORK_NAME}" | awk -F':' '/Bridge/ {print $2}' | tr -d ' ')
     fi
 
     if [ -f "/var/lib/libvirt/dnsmasq/${BRIDGE}.status" ]

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -59,6 +59,7 @@ function usage_subcommand ()
             printf "    -L          Location of VMs       (default: $HOME/virt/vms)\n"
             printf "    -m          Memory Size (MB)      (default: 1024)\n"
             printf "    -M          Mac address           (default: auto-assigned)\n"
+            printf "    -n          Network name\n"
             printf "    -p          Console port          (default: auto)\n"
             printf "    -s          Custom shell script\n"
             printf "    -t          Linux Distribution    (default: centos7)\n"
@@ -618,11 +619,14 @@ _EOF_
         || die "Could not create storage pool."
 
     # Add custom MAC Address if specified
-    NETWORK_PARAMS="$(join ',' \
-        $(param bridge ${BRIDGE}) \
-        $(param model ${NETWORK_MODEL}) \
-        $(param mac ${MACADDRESS}) \
-        ${NETWORK_EXTRA})"
+    NETWORK_PARAMS=$(param network ${NETWORK_NAME})
+    if [ -z "${NETWORK_PARAMS}" ]; then
+        NETWORK_PARAMS="$(join ',' \
+            $(param bridge ${BRIDGE}) \
+            $(param model ${NETWORK_MODEL}) \
+            $(param mac ${MACADDRESS}) \
+            ${NETWORK_EXTRA})"
+    fi
 
     # Assemble disk parameters.
     DISK_PARAMS="$(join ',' \
@@ -690,6 +694,10 @@ _EOF_
     # Remove the unnecessary cloud init files
     outputn "Cleaning up cloud-init files"
     rm -f $USER_DATA $META_DATA $CI_ISO && ok
+
+    if [ ! -z "${NETWORK_NAME}" ]; then
+        BRIDGE=$(virsh net-dumpxml "${NETWORK_NAME}" | awk -F\' '/bridge/ {print $2}')
+    fi
 
     if [ -f "/var/lib/libvirt/dnsmasq/${BRIDGE}.status" ]
     then
@@ -811,7 +819,7 @@ function set_custom_defaults ()
 function create ()
 {
     # Parse command line arguments
-    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:p:s:t:T:u:ahynv" opt
+    while getopts ":b:c:d:D:f:g:i:k:l:L:m:M:n:p:s:t:T:u:ahynv" opt
     do
         case "$opt" in
             a ) AUTOSTART=${OPTARG} ;;
@@ -827,6 +835,7 @@ function create ()
             L ) VMDIR="${OPTARG}" ;;
             m ) MEMORY="${OPTARG}" ;;
             M ) MACADDRESS="${OPTARG}" ;;
+            n ) NETWORK_NAME="${OPTARG}" ;;
             p ) PORT="${OPTARG}" ;;
             s ) SCRIPTNAME="${OPTARG}" ;;
             t ) DISTRO="${OPTARG}" ;;


### PR DESCRIPTION
This PR resurrects an earlier closed one (https://github.com/giovtorres/kvm-install-vm/pull/43), which added the `-n` parameter to allow attaching of VMs to defined libvirt networks at creation. I have just rebased that PR on top of the latest `master` branch, and added the last suggestion from the discussion on PR #43 about the bridge extraction command.
It's working for my needs! Happy to take on any further comments that would see it merged back upsteam.