### PR TITLE
feat: support qcow2, raw and vhd images with -i flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Bash wrapper around `virt-install` to quickly spin up and manage local KVM vir
 
 - 🚀 One-command VM provisioning with sensible defaults
 - 🌐 Support for multiple distro cloud-images (AlmaLinux, Debian, Rocky, Ubuntu, and more)
+- 💽 Bring your own custom image (.qcow2, .raw or .vhd)
 - 🔧 Customize CPU, RAM, disk size, architecture, and timezone
 - 💾 Attach additional disks on the fly
 - 🖥️ Boot using BIOS or UEFI (SecureBoot enabled or disabled)
@@ -112,6 +113,24 @@ kvm-install-vm create myvm
 - `-A, --arch <ARCH>`    Architecture (x86_64 or aarch64)
 - `-t, --distro <NAME>`  Distro key (see BUILTIN_VMS)
 - `-T, --tz <ZONE>`      Timezone (default: host timezone)
+- `-i, --image <PATH>`   Use custom image file instead of downloading
+
+#### Using Custom Images
+
+You can create VMs from existing disk images using the `-i` flag:
+
+```bash
+# Create VM from a custom qcow2 image
+kvm-install-vm create -i /path/to/custom-image.qcow2 myinstance
+```
+
+The script automatically detects the disk format based on the file extension:
+- `.qcow2` files are treated as QCOW2 format
+- `.raw` files are treated as RAW format
+- `.vhd` files are treated as VPC format
+
+You can combine the `-i` flag with other options like `-c`, `-m`, `-d` to
+customize the VM resources.
 
 ### Delete a VM
 

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -367,6 +367,26 @@ function check_delete_known_host() {
         output "No entries found for ${IP}"
 }
 
+function detect_disk_format() {
+    local image_path="$1"
+    local extension="${image_path##*.}"
+
+    case "${extension,,}" in
+        qcow2)
+            echo "qcow2"
+            ;;
+        raw)
+            echo "raw"
+            ;;
+        vhd)
+            echo "vpc"
+            ;;
+        *)
+            echo "qcow"
+            ;;
+    esac
+}
+
 function set_boot_flag() {
     local share_dir=""
 
@@ -471,7 +491,13 @@ _EOF_
 
     outputn "Copying cloud image ($(basename ${IMAGE}))"
     DISK=${VMNAME}.qcow2
-    qemu-img create -q -f qcow2 -F qcow2 -b $IMAGE $DISK && ok
+
+    if [ "${DISK_FORMAT}" = "qcow2" ]; then
+        qemu-img create -q -f qcow2 -F qcow2 -b $IMAGE $DISK && ok
+    else
+        qemu-img create -q -f qcow2 -F "${DISK_FORMAT}" -b $IMAGE $DISK && ok
+    fi
+
     if $RESIZE_DISK; then
         outputn "Resizing the disk to $DISK_SIZE"
         # Workaround to prevent virt-resize from renumbering partitions and breaking grub
@@ -809,8 +835,9 @@ function create() {
     check_ssh_key
 
     if [ ! -z "${IMAGE+x}" ]; then
-        output "Using custom QCOW2 image: ${IMAGE}."
-        OS_INFO="auto"
+        DISK_FORMAT=$(detect_disk_format "${IMAGE}")
+        output "Using custom image: ${IMAGE} (format: ${DISK_FORMAT})."
+        OS_INFO="linux2024"
         LOGIN_USER="<use the default account in your custom image>"
     else
         fetch_images


### PR DESCRIPTION
This change adds support for detecting the image type from the file extension of the provided image when using the `-i` flag. This adds support for QCOW2, RAW and VHD images.