### PR TITLE
feat: cleanup if domain not created successfully

### DIFF
--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -559,7 +559,7 @@ _EOF_
     CLOUD_INIT_OPTION="$(param --cloud-init user-data=${USER_DATA},meta-data=${META_DATA},disable=on)"
 
     # Call virt-install to import the cloud image and create a new VM
-    run "Installing the domain" \
+    if ! run "Installing the domain" \
         virt-install --import \
         --name=${VMNAME} \
         --memory=${MEMORY} \
@@ -573,8 +573,13 @@ _EOF_
         --noautoconsole \
         ${GRAPHICS_OPTION} \
         ${BOOTFLAG} \
-        ${VIRT_INSTALL_EXTRA} ||
+        ${VIRT_INSTALL_EXTRA}; then
+        # Cleanup on failure
+        red "VM creation failed. Cleaning up..."
+        popd
+        delete_vm
         die "Could not create domain with virt-install."
+    fi
 
     virsh dominfo ${VMNAME} &>> ${VMNAME}.log
 

--- a/kvm-install-vm
+++ b/kvm-install-vm
@@ -574,8 +574,17 @@ _EOF_
         ${GRAPHICS_OPTION} \
         ${BOOTFLAG} \
         ${VIRT_INSTALL_EXTRA}; then
+
         # Cleanup on failure
         red "VM creation failed. Cleaning up..."
+
+        if [ "${VERBOSE}" -eq 1 ] && [ -f "${VMNAME}.log" ]; then
+            yellow "Log contents:"
+            cat "${VMNAME}.log"
+        else
+            yellow "Run with -v flag to see detailed logs"
+        fi
+
         popd
         delete_vm
         die "Could not create domain with virt-install."


### PR DESCRIPTION
This change enhances the domain creation such that if it fails, it cleans up after itself. Otherwise, you would have to run `remove` manually, and then try to re-create. It also emits the contents of the log file before cleaning up when run with the verbose flag.